### PR TITLE
Fix typo in undefined?() fn in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -218,8 +218,8 @@ Boolean
 ##### Examples
 
 ```js
-undefined?("foo") ; => true
-undefined?(undefined) ; => false
+undefined?("foo") ; => false
+undefined?(undefined) ; => true
 ```
 
 #### =


### PR DESCRIPTION
Fix typo in documentation for `undefined?` function